### PR TITLE
Multiple spawn added (only horizontal now)

### DIFF
--- a/resources/stage.gd
+++ b/resources/stage.gd
@@ -9,3 +9,5 @@ class_name Stage extends Resource
 ## Rate at which food is spawned.
 @export var spawn_time:float = 2.0
 @export var music:AudioStream
+@export var chance_of_multiple_spawn: float = 10
+@export var max_multiple_spawn_num: int = 2

--- a/scenes/main_game/food_spawner.gd
+++ b/scenes/main_game/food_spawner.gd
@@ -10,16 +10,33 @@ var food_types:Array[FoodType]
 
 func _ready() -> void:
 	food_type_group.load_all_into(food_types)
-	spawn_timer.timeout.connect(_spawn_food)
+	spawn_timer.timeout.connect(func():
+		var multiple_spawn_chance: float = randf_range(0, 100)
+		var food_spawned: Food = _spawn_food()
+		if multiple_spawn_chance < stage_manager.stage.chance_of_multiple_spawn:
+			var position_increment: float = 0
+			var amount_to_spawn: int = randi_range(1, stage_manager.stage.max_multiple_spawn_num)
+			for times in amount_to_spawn:
+				position_increment+= 1
+				var food_position = food_spawned.position
+				food_position.x += position_increment
+				_spawn_food(true, true, food_spawned.type, food_position)
+				pass
+		)
 	stage_manager.stage_changed.connect(func(level:int, stage:Stage):
 		spawn_timer.wait_time = stage.spawn_time / max(1,level/stage_manager.stages.size())
 	)
 
-func _spawn_food() -> void:
+func _spawn_food(gave_type: bool = false, gave_position: bool = false, given_type: FoodType = null, given_position: Vector3 = Vector3.INF) -> Food:
 	var food:Food = FoodScene.instantiate() as Food
-	food.type = food_types.pick_random()
-	food.position = _get_spawnpoint()
-	
+	if not gave_type:
+		food.type = food_types.pick_random()
+	else:
+		food.type = given_type
+	if not gave_position:
+		food.position = _get_spawnpoint()
+	else:
+		food.position = given_position
 	# Apply current gravity scale to the food
 	food.gravity_scale = stage_manager.stage.gravity_scale
 	
@@ -28,6 +45,7 @@ func _spawn_food() -> void:
 			game.strikes += 1
 	)
 	add_child(food)
+	return food
 	
 func _get_spawnpoint() -> Vector3:
 	var box:BoxShape3D = spawn_area.shape as BoxShape3D

--- a/scenes/main_game/main_game.tscn
+++ b/scenes/main_game/main_game.tscn
@@ -99,6 +99,8 @@ stage_name = "The Basics"
 gravity_scale = 0.5
 spawn_time = 5.0
 music = ExtResource("11_fetp2")
+chance_of_multiple_spawn = 0.0
+max_multiple_spawn_num = 0
 metadata/_custom_type_script = "uid://byftv7ev26bdr"
 
 [sub_resource type="Resource" id="Resource_ebk6p"]
@@ -108,6 +110,8 @@ stage_name = "Hungry for More?"
 gravity_scale = 0.75
 spawn_time = 4.0
 music = ExtResource("11_fetp2")
+chance_of_multiple_spawn = 15.0
+max_multiple_spawn_num = 1
 metadata/_custom_type_script = "uid://byftv7ev26bdr"
 
 [sub_resource type="Resource" id="Resource_irrf2"]
@@ -117,6 +121,8 @@ stage_name = "Now We're Cooking"
 gravity_scale = 1.0
 spawn_time = 3.0
 music = ExtResource("13_l774p")
+chance_of_multiple_spawn = 25.0
+max_multiple_spawn_num = 1
 metadata/_custom_type_script = "uid://byftv7ev26bdr"
 
 [sub_resource type="Resource" id="Resource_l774p"]
@@ -126,6 +132,8 @@ stage_name = "Hot enough for you?"
 gravity_scale = 1.0
 spawn_time = 2.0
 music = ExtResource("14_r8wn4")
+chance_of_multiple_spawn = 25.0
+max_multiple_spawn_num = 2
 metadata/_custom_type_script = "uid://byftv7ev26bdr"
 
 [sub_resource type="Resource" id="Resource_r8wn4"]
@@ -135,6 +143,8 @@ stage_name = "Let's go!"
 gravity_scale = 1.0
 spawn_time = 1.0
 music = ExtResource("14_r8wn4")
+chance_of_multiple_spawn = 30.0
+max_multiple_spawn_num = 2
 metadata/_custom_type_script = "uid://byftv7ev26bdr"
 
 [sub_resource type="AudioStreamRandomizer" id="AudioStreamRandomizer_ebk6p"]


### PR DESCRIPTION
closes #54 

Now that  fruits (or bombs) spawn in rows (multiple instances) that means that you have to upgrade your crate size to collect all 2 or 3 fruits. (numbers can be adjusted but for now, 4 fruits and above is kind impossible to catch)